### PR TITLE
Repository state testing framework: init

### DIFF
--- a/test-harness/src/helpers.rs
+++ b/test-harness/src/helpers.rs
@@ -22,6 +22,8 @@ pub fn setup_repo_multiple_remotes(
             cp -r "{basename}" "$repo"
             pushd "$repo" || exit
             git switch -c "$repo"
+            echo "I am on branch $repo" > README.md
+            git commit -am "Update README.md"
             git branch -D main
             popd || exit
             popd || exit

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -4,13 +4,10 @@ use std::process::Command;
 use camino::Utf8PathBuf;
 use clonable_command::Command as ClonableCommand;
 use command_error::CommandExt;
-use expect_test::Expect;
 use fs_err as fs;
-use git_prole::format_bulleted_list;
 use git_prole::Git;
 use git_prole::Utf8TempDir;
 use itertools::Itertools;
-use miette::miette;
 use miette::Context;
 use miette::IntoDiagnostic;
 
@@ -101,39 +98,6 @@ impl GitProle {
         self.tempdir.join(tail)
     }
 
-    pub fn exists(&self, path: &str) -> bool {
-        self.path(path).exists()
-    }
-
-    pub fn contents(&self, path: &str) -> miette::Result<String> {
-        fs::read_to_string(self.path(path)).into_diagnostic()
-    }
-
-    #[track_caller]
-    pub fn assert_exists(&self, paths: &[&str]) {
-        let mut missing = Vec::new();
-        for path in paths {
-            if !self.exists(path) {
-                missing.push(path);
-            }
-        }
-
-        if !missing.is_empty() {
-            panic!(
-                "{:?}",
-                miette!("Paths are missing:\n{}", format_bulleted_list(missing))
-            )
-        }
-    }
-
-    #[track_caller]
-    pub fn assert_contents(&self, contents: &[(&str, Expect)]) {
-        for (path, expect) in contents {
-            let actual = self.contents(path).unwrap();
-            expect.assert_eq(&actual);
-        }
-    }
-
     pub fn sh(&self, script: &str) -> miette::Result<()> {
         let tempfile = tempfile::NamedTempFile::new().into_diagnostic()?;
         fs::write(
@@ -168,26 +132,6 @@ impl GitProle {
             })
         }));
         git
-    }
-
-    pub fn current_branch_in(&self, directory: &str) -> miette::Result<String> {
-        Ok(self
-            .git(directory)
-            .branch()
-            .current()?
-            .ok_or_else(|| miette!("HEAD is detached in {directory}"))?
-            .branch_name()
-            .to_owned())
-    }
-
-    pub fn upstream_for_branch_in(&self, directory: &str, branch: &str) -> miette::Result<String> {
-        Ok(self
-            .git(directory)
-            .branch()
-            .upstream(branch)?
-            .ok_or_else(|| miette!("Branch {branch} has no upstream in {directory}"))?
-            .qualified_branch_name()
-            .to_owned())
     }
 
     /// Set up a new repository in `path` with a single commit.

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -15,8 +15,11 @@ use miette::Context;
 use miette::IntoDiagnostic;
 
 mod helpers;
+mod repo_state;
 
 pub use helpers::*;
+pub use repo_state::RepoState;
+pub use repo_state::WorktreeState;
 
 /// `git-prole` session for integration testing.
 pub struct GitProle {
@@ -222,5 +225,12 @@ impl GitProle {
             .into_diagnostic()
             .wrap_err("Failed to write `git-prole` configuration")?;
         Ok(())
+    }
+
+    /// Construct a repository state which a real repository can be checked against.
+    ///
+    /// The repository state will rooted in the given directory.
+    pub fn repo_state(&self, root: &str) -> RepoState {
+        RepoState::new(self.git(root))
     }
 }

--- a/test-harness/src/repo_state.rs
+++ b/test-harness/src/repo_state.rs
@@ -1,0 +1,488 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::str::FromStr;
+
+use camino::Utf8PathBuf;
+use expect_test::Expect;
+use fs_err as fs;
+use git_prole::format_bulleted_list_multiline;
+use git_prole::BranchRef;
+use git_prole::Git;
+use git_prole::LocalBranchRef;
+use git_prole::Ref;
+use git_prole::RemoteBranchRef;
+use git_prole::Status;
+use git_prole::StatusEntry;
+use git_prole::Worktree;
+use git_prole::WorktreeHead;
+use itertools::Itertools;
+use pretty_assertions::assert_eq;
+use pretty_assertions::Comparison;
+
+/// A repository state, which can be checked against a real repository.
+#[derive(Debug)]
+pub struct RepoState {
+    git: Git,
+    root: Utf8PathBuf,
+    git_dir: Option<Utf8PathBuf>,
+    worktrees: Option<Vec<WorktreeState>>,
+}
+
+impl RepoState {
+    /// Construct a new repository state with the given [`Git`] object.
+    ///
+    /// The [`Git`]'s directory is used as the repository root.
+    pub fn new(git: Git) -> Self {
+        let root = git.get_directory().to_owned();
+        Self {
+            git,
+            root,
+            git_dir: Default::default(),
+            worktrees: Default::default(),
+        }
+    }
+
+    /// Expect the repository to have its `.git` directory at the given path, relative to the
+    /// repository root.
+    pub fn git_dir(mut self, path: &str) -> Self {
+        self.git_dir = Some(self.root.join(path));
+        self
+    }
+
+    /// Expect the repository to have the given worktrees.
+    pub fn worktrees(mut self, worktrees: impl IntoIterator<Item = WorktreeState>) -> Self {
+        self.worktrees = Some(worktrees.into_iter().collect());
+        self
+    }
+
+    /// Assert that the repository state matches the actual repository.
+    ///
+    /// # Panics
+    ///
+    /// If the repository state doesn't match the actual repository.
+    #[track_caller]
+    pub fn assert(&self) {
+        if let Some(git_dir) = &self.git_dir {
+            assert_eq!(
+                self.git.path().git_common_dir().unwrap(),
+                // NOTE: Seems I have to canonicalize paths to avoid finicky problems with `/tmp`
+                // vs. `/private/tmp` on macOS (the former being a symlink to the latter).
+                git_dir.canonicalize_utf8().unwrap()
+            );
+        }
+
+        let mut problems = Vec::new();
+
+        if let Some(worktrees) = &self.worktrees {
+            let actual_worktrees = self.git.worktree().list().unwrap();
+            let mut expected_worktrees = worktrees
+                .iter()
+                .map(|worktree| {
+                    (
+                        self.root
+                            .join(&worktree.path)
+                            .canonicalize_utf8()
+                            .expect("Worktree path should be canonicalize-able"),
+                        worktree,
+                    )
+                })
+                .collect::<HashMap<_, _>>();
+
+            for (_, actual) in actual_worktrees.iter() {
+                let expected = match expected_worktrees.remove(&actual.path) {
+                    Some(expected) => expected,
+                    None => {
+                        problems.push(format!("Found unexpected worktree: {actual}"));
+                        continue;
+                    }
+                };
+                let worktree_problems = WorktreeState::check(&self.git, expected, actual);
+                if !worktree_problems.is_empty() {
+                    problems.push(format!(
+                        "Worktree {}:\n{}",
+                        expected.path,
+                        format_bulleted_list_multiline(worktree_problems)
+                    ));
+                }
+            }
+
+            if !expected_worktrees.is_empty() {
+                problems.push(format!(
+                    "Worktrees not found:\n{}",
+                    format_bulleted_list_multiline(
+                        expected_worktrees
+                            .values()
+                            .map(|worktree| worktree.path.clone())
+                    )
+                ));
+            }
+        }
+
+        if !problems.is_empty() {
+            panic!("{}", format_bulleted_list_multiline(problems));
+        }
+    }
+}
+
+/// A Git worktree's state.
+///
+/// Used with [`RepoState`] to validate a worktree state against an actual worktree.
+#[derive(Debug)]
+pub struct WorktreeState {
+    path: String,
+    is_main: Option<bool>,
+    head: Option<WorktreeHeadState>,
+    files: Option<Vec<(String, Option<Expect>)>>,
+    upstream: Option<Option<BranchRef>>,
+    status: Option<Status>,
+}
+
+impl WorktreeState {
+    /// Expect a worktree in the given path, relative to the repository root.
+    pub fn new(path: &str) -> Self {
+        Self {
+            path: path.into(),
+            is_main: Default::default(),
+            head: Default::default(),
+            files: Default::default(),
+            upstream: Default::default(),
+            status: Default::default(),
+        }
+    }
+
+    /// A new bare worktree at the root of the containing repo.
+    ///
+    /// This is used if a bare worktree named `.git` is present at the repository root.
+    pub fn new_bare() -> Self {
+        Self::new("").bare()
+    }
+
+    /// This worktree is bare.
+    pub fn bare(mut self) -> Self {
+        self.is_main = Some(true);
+        self.head = Some(WorktreeHeadState::Bare);
+        self
+    }
+
+    /// This worktree is or is not a main worktree.
+    pub fn is_main(mut self, is_main: bool) -> Self {
+        self.is_main = Some(is_main);
+        self
+    }
+
+    /// This worktree is detached at the given commit.
+    ///
+    /// The given commit must be a prefix of the actual commit; this lets you use either a full
+    /// 40-character commit hash or an abbreviated hash.
+    pub fn detached(mut self, commit: &str) -> Self {
+        self.head = Some(WorktreeHeadState::Detached(commit.into()));
+        self
+    }
+
+    /// This worktree is on the given branch.
+    pub fn branch(mut self, branch: &str) -> Self {
+        self.head = Some(WorktreeHeadState::Branch(
+            None,
+            LocalBranchRef::from(branch),
+        ));
+        self
+    }
+
+    /// This worktree is on the given commit.
+    ///
+    /// # Panics
+    ///
+    /// If [`WorktreeState::branch`] hasn't been called; use [`WorktreeState::detached`] to specify
+    /// a detached `HEAD` commit.
+    #[track_caller]
+    pub fn commit(mut self, commit: &str) -> Self {
+        self.head = match self.head {
+            Some(WorktreeHeadState::Branch(_, branch)) => {
+                Some(WorktreeHeadState::Branch(Some(commit.into()), branch))
+            }
+            _ => {
+                panic!(".commit() can only be used on branch worktrees; use .detached() for detached worktrees")
+            }
+        };
+        self
+    }
+
+    /// Expect the worktree's branch to have the given branch as its upstream.
+    ///
+    /// If the given branch contains a `/`, it's assumed to be a remote-tracking branch like
+    /// `origin/main`.
+    ///
+    /// # Panics
+    ///
+    /// If [`WorktreeState::branch`] hasn't been called.
+    pub fn upstream(mut self, branch: &str) -> Self {
+        if !matches!(&self.head, Some(WorktreeHeadState::Branch(_, _))) {
+            panic!(
+                ".upstream() can only be used on branch worktrees; specify a branch with .branch()"
+            );
+        }
+
+        self.upstream = Some(Some(if branch.contains('/') {
+            RemoteBranchRef::try_from(Ref::new(Ref::REMOTES.into(), branch.into()))
+                .unwrap()
+                .into()
+        } else {
+            LocalBranchRef::try_from(Ref::new(Ref::HEADS.into(), branch.into()))
+                .unwrap()
+                .into()
+        }));
+        self
+    }
+
+    /// Expect the worktree's branch to have no upstream.
+    ///
+    /// # Panics
+    ///
+    /// If [`WorktreeState::branch`] hasn't been called.
+    pub fn no_upstream(mut self) -> Self {
+        if !matches!(&self.head, Some(WorktreeHeadState::Branch(_, _))) {
+            panic!(".no_upstream() can only be used on branch worktrees; specify a branch with .branch()");
+        }
+
+        self.upstream = Some(None);
+        self
+    }
+
+    /// Expect a file at the given path to have the given contents.
+    pub fn file(mut self, path: &str, contents: Expect) -> Self {
+        self.files = match self.files {
+            Some(mut files) => {
+                files.push((path.into(), Some(contents)));
+                Some(files)
+            }
+            None => Some(vec![(path.into(), Some(contents))]),
+        };
+        self
+    }
+
+    /// Expect a file at the given path to _not_ exist.
+    pub fn no_file(mut self, path: &str) -> Self {
+        self.files = match self.files {
+            Some(mut files) => {
+                files.push((path.into(), None));
+                Some(files)
+            }
+            None => Some(vec![(path.into(), None)]),
+        };
+        self
+    }
+
+    /// Expect the worktree's `git status` to have the given entries.
+    #[track_caller]
+    pub fn status<'a>(mut self, entries: impl IntoIterator<Item = &'a str>) -> Self {
+        self.status = Some(Status {
+            entries: entries
+                .into_iter()
+                // lol, lmao
+                .map(|entry| StatusEntry::from_str(&format!("{entry}\0")))
+                .collect::<Result<Vec<_>, _>>()
+                .expect("All expected status entries parse succesfully"),
+        });
+        self
+    }
+
+    #[track_caller]
+    fn check(git: &Git, expected: &Self, actual: &Worktree) -> Vec<String> {
+        let mut problems = Vec::new();
+        let git = git.with_directory(actual.path.clone());
+
+        Self::check_is_main(&mut problems, expected, actual);
+        Self::check_head(&mut problems, expected, actual);
+        Self::check_files(&mut problems, expected, actual);
+        Self::check_status(&mut problems, &git, expected, actual);
+
+        problems
+    }
+
+    #[track_caller]
+    fn check_is_main(problems: &mut Vec<String>, expected: &Self, actual: &Worktree) {
+        let expected_is_main = match expected.is_main {
+            Some(expected_is_main) => expected_is_main,
+            None => {
+                return;
+            }
+        };
+
+        if expected_is_main != actual.is_main {
+            if expected_is_main {
+                problems.push("Worktree is not main worktree, expected main worktree".into());
+            } else {
+                problems.push("Worktree is main worktree, expected non-main worktree".into());
+            }
+        }
+    }
+
+    #[track_caller]
+    fn check_head(problems: &mut Vec<String>, expected: &Self, actual: &Worktree) {
+        let expected_head = match &expected.head {
+            Some(head) => head,
+            None => {
+                return;
+            }
+        };
+
+        let actual_head = &actual.head;
+
+        match expected_head {
+            WorktreeHeadState::Bare => {
+                if !actual.head.is_bare() {
+                    problems.push(format!("Expected bare worktree: {actual_head}"));
+                }
+            }
+
+            WorktreeHeadState::Detached(commit) => match &actual.head {
+                WorktreeHead::Detached(actual_commit) => {
+                    if !actual_commit.starts_with(commit) {
+                        problems.push(format!("Expected detached HEAD at {commit}: {actual_head}"));
+                    }
+                }
+                _ => {
+                    problems.push(format!("Expected detached HEAD at {commit}: {actual_head}"));
+                }
+            },
+
+            WorktreeHeadState::Branch(commit, branch) => match &actual.head {
+                WorktreeHead::Branch(actual_commit, actual_branch) => {
+                    if branch != actual_branch {
+                        problems.push(format!(
+                            "Expected branch {branch}, found {actual_branch}: {actual_head}"
+                        ));
+                    }
+
+                    if let Some(commit) = commit {
+                        if !actual_commit.starts_with(commit) {
+                            problems.push(format!("Expected branch {branch} at {commit}, found {actual_commit}: {actual_head}"));
+                        }
+                    }
+                }
+                _ => {
+                    problems.push(format!("Expected branch {branch}: {actual_head}"));
+                }
+            },
+        }
+    }
+
+    #[track_caller]
+    fn check_files(problems: &mut Vec<String>, expected: &Self, actual: &Worktree) {
+        let expected_path = &expected.path;
+
+        let expected_files = match &expected.files {
+            Some(files) => files,
+            None => {
+                return;
+            }
+        };
+
+        for (path, contents) in expected_files {
+            let actual_path = actual.path.join(path);
+
+            match contents {
+                None => {
+                    if actual_path.exists() {
+                        problems.push(format!(
+                            "Path exists in {expected_path}, but should not: {path}"
+                        ));
+                    }
+                }
+                Some(contents) => {
+                    if !actual_path.exists() {
+                        problems.push(format!(
+                            "Expected path does not exist in {expected_path}, but should: {path}"
+                        ));
+                        continue;
+                    }
+
+                    match fs::read_to_string(&actual_path) {
+                        Ok(actual_contents) => {
+                            contents.assert_eq(&actual_contents);
+                        }
+                        Err(err) => {
+                            problems.push(format!(
+                                "Failed to read contents in worktree {expected_path}: {path}: {err}"
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[track_caller]
+    fn check_status(problems: &mut Vec<String>, git: &Git, expected: &Self, actual: &Worktree) {
+        let expected_path = &expected.path;
+
+        let expected_status = match &expected.status {
+            Some(expected_status) => expected_status,
+            None => {
+                return;
+            }
+        };
+
+        match git.status().get() {
+            Ok(actual_status) => {
+                let sorted_entries = |status: &Status| -> Vec<String> {
+                    status
+                        .entries
+                        .iter()
+                        .map(|entry| entry.to_string())
+                        .sorted()
+                        .collect()
+                };
+
+                let actual_entries = sorted_entries(&actual_status);
+                let expected_entries = sorted_entries(expected_status);
+
+                if actual_entries != expected_entries {
+                    problems.push(format!(
+                        "Git status differs in {expected_path}:\n{}",
+                        Comparison::new(&actual_entries, &expected_entries)
+                    ));
+                }
+            }
+            Err(err) => {
+                problems.push(format!(
+                    "Failed to get Git status in {}: {err}",
+                    actual.path
+                ));
+            }
+        };
+    }
+}
+
+impl Display for WorktreeState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.path)?;
+
+        match &self.head {
+            Some(head) => write!(f, " [{head}]")?,
+            None => {}
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+enum WorktreeHeadState {
+    Bare,
+    Detached(String),
+    Branch(Option<String>, LocalBranchRef),
+}
+
+impl Display for WorktreeHeadState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            Self::Bare => write!(f, "bare"),
+            Self::Detached(commit) => write!(f, "detached at {commit}"),
+            Self::Branch(commit, branch) => match commit {
+                Some(commit) => write!(f, "{branch} at {commit}"),
+                None => write!(f, "{branch}"),
+            },
+        }
+    }
+}

--- a/tests/add_branch_and_name.rs
+++ b/tests/add_branch_and_name.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_branch_and_name() {
@@ -14,19 +14,25 @@ fn add_branch_and_name() {
         .status_checked()
         .unwrap();
 
-    prole.assert_contents(&[(
-        "my-repo/puppy/README.md",
-        expect![[r#"
-            puppy doggy
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/puppy").unwrap(), "doggy");
-
-    assert_eq!(
-        prole
-            .upstream_for_branch_in("my-repo/puppy", "doggy")
-            .unwrap(),
-        "main"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main").file(
+                "README.md",
+                expect![[r#"
+                    puppy doggy
+                "#]],
+            ),
+            WorktreeState::new("puppy")
+                .branch("doggy")
+                .upstream("main")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        puppy doggy
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_branch_and_path.rs
+++ b/tests/add_branch_and_path.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_branch_and_path() {
@@ -14,19 +14,20 @@ fn add_branch_and_path() {
         .status_checked()
         .unwrap();
 
-    prole.assert_contents(&[(
-        "my-repo/puppy/README.md",
-        expect![[r#"
-            puppy doggy
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/puppy").unwrap(), "doggy");
-
-    assert_eq!(
-        prole
-            .upstream_for_branch_in("my-repo/puppy", "doggy")
-            .unwrap(),
-        "main"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("puppy")
+                .branch("doggy")
+                .upstream("main")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        puppy doggy
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_branch_new_local.rs
+++ b/tests/add_branch_new_local.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_branch_new_local() {
@@ -13,12 +13,20 @@ fn add_branch_new_local() {
         .status_checked()
         .unwrap();
 
-    prole.assert_contents(&[(
-        "my-repo/puppy/README.md",
-        expect![[r#"
-            puppy doggy
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/puppy").unwrap(), "puppy");
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("puppy")
+                .branch("puppy")
+                .upstream("main")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        puppy doggy
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_branch_start_point_existing_local.rs
+++ b/tests/add_branch_start_point_existing_local.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_branch_start_point_existing_local() {
@@ -25,19 +25,20 @@ fn add_branch_start_point_existing_local() {
         .status_checked()
         .unwrap();
 
-    prole.assert_contents(&[(
-        "my-repo/puppy/README.md",
-        expect![[r#"
-            cutie puppy
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/puppy").unwrap(), "softy");
-
-    assert_eq!(
-        prole
-            .upstream_for_branch_in("my-repo/puppy", "softy")
-            .unwrap(),
-        "doggy"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("puppy")
+                .branch("softy")
+                .upstream("doggy")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        cutie puppy
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_branch_start_point_existing_remote.rs
+++ b/tests/add_branch_start_point_existing_remote.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_branch_start_point_existing_remote() {
@@ -30,21 +30,20 @@ fn add_branch_start_point_existing_remote() {
         .status_checked()
         .unwrap();
 
-    // We get a checkout for the remote-tracking branch!
-    prole.assert_contents(&[(
-        "my-repo/doggy/README.md",
-        expect![[r#"
-            softy pup
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/doggy").unwrap(), "softie");
-
-    // We're tracking the remote branch we expect.
-    assert_eq!(
-        prole
-            .upstream_for_branch_in("my-repo/doggy", "softie")
-            .unwrap(),
-        "origin/puppy"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("doggy")
+                .branch("softie")
+                .upstream("origin/puppy")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        softy pup
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_branch_start_point_new_local.rs
+++ b/tests/add_branch_start_point_new_local.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_branch_start_point_new_local() {
@@ -23,12 +23,21 @@ fn add_branch_start_point_new_local() {
         .status_checked()
         .unwrap();
 
-    prole.assert_contents(&[(
-        "my-repo/doggy/README.md",
-        expect![[r#"
-            soft cutie
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/doggy").unwrap(), "softy");
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            // We `git switch`ed from `main` earlier.
+            WorktreeState::new("main").branch("puppy"),
+            WorktreeState::new("doggy")
+                .branch("softy")
+                .no_upstream()
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        soft cutie
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_by_name_existing_local.rs
+++ b/tests/add_by_name_existing_local.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_by_name_existing_local() {
@@ -25,13 +25,20 @@ fn add_by_name_existing_local() {
         .status_checked()
         .unwrap();
 
-    // We get a checkout for the existing branch.
-    prole.assert_contents(&[(
-        "my-repo/puppy/README.md",
-        expect![[r#"
-            softy pup
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/puppy").unwrap(), "puppy");
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("puppy")
+                .branch("puppy")
+                .upstream("main")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        softy pup
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_by_name_existing_remote.rs
+++ b/tests/add_by_name_existing_remote.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_by_name_existing_remote() {
@@ -30,21 +30,20 @@ fn add_by_name_existing_remote() {
         .status_checked()
         .unwrap();
 
-    // We get a checkout for the remote-tracking branch!
-    prole.assert_contents(&[(
-        "my-repo/puppy/README.md",
-        expect![[r#"
-            softy pup
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/puppy").unwrap(), "puppy");
-
-    // We're tracking the remote branch we expect.
-    assert_eq!(
-        prole
-            .upstream_for_branch_in("my-repo/puppy", "puppy")
-            .unwrap(),
-        "origin/puppy"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("puppy")
+                .branch("puppy")
+                .upstream("origin/puppy")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        softy pup
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_by_name_new_local.rs
+++ b/tests/add_by_name_new_local.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_by_name_new_local() {
@@ -25,19 +25,20 @@ fn add_by_name_new_local() {
         .status_checked()
         .unwrap();
 
-    prole.assert_contents(&[(
-        "my-repo/puppy/README.md",
-        expect![[r#"
-            puppy doggy
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/puppy").unwrap(), "puppy");
-
-    assert_eq!(
-        prole
-            .upstream_for_branch_in("my-repo/puppy", "puppy")
-            .unwrap(),
-        "main"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("doggy"),
+            WorktreeState::new("puppy")
+                .branch("puppy")
+                .upstream("main")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        puppy doggy
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_by_path.rs
+++ b/tests/add_by_path.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_by_path() {
@@ -15,18 +15,20 @@ fn add_by_path() {
         .status_checked()
         .unwrap();
 
-    prole.assert_contents(&[(
-        "puppy/README.md",
-        expect![[r#"
-            puppy doggy
-        "#]],
-    )]);
-
-    // Last component of the path becomes the branch name.
-    assert_eq!(prole.current_branch_in("puppy").unwrap(), "puppy");
-
-    assert_eq!(
-        prole.upstream_for_branch_in("puppy", "puppy").unwrap(),
-        "main"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("../puppy")
+                .branch("puppy")
+                .upstream("main")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        puppy doggy
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_by_path_existing_branch.rs
+++ b/tests/add_by_path_existing_branch.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_by_path_existing_branch() {
@@ -26,18 +26,21 @@ fn add_by_path_existing_branch() {
         .status_checked()
         .unwrap();
 
-    prole.assert_contents(&[(
-        "puppy/README.md",
-        expect![[r#"
-            softy pup
-        "#]],
-    )]);
-
-    // Last component of the path becomes the branch name.
-    assert_eq!(prole.current_branch_in("puppy").unwrap(), "puppy");
-
-    assert_eq!(
-        prole.upstream_for_branch_in("puppy", "puppy").unwrap(),
-        "main"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("../puppy")
+                // Last component of the path becomes the branch name.
+                .branch("puppy")
+                .upstream("main")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        softy pup
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_start_point_existing_local.rs
+++ b/tests/add_start_point_existing_local.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_start_point_existing_local() {
@@ -25,12 +25,20 @@ fn add_start_point_existing_local() {
         .status_checked()
         .unwrap();
 
-    prole.assert_contents(&[(
-        "my-repo/puppy/README.md",
-        expect![[r#"
-            cutie puppy
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/puppy").unwrap(), "doggy");
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("puppy")
+                .branch("doggy")
+                .no_upstream()
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        cutie puppy
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_start_point_existing_remote.rs
+++ b/tests/add_start_point_existing_remote.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_start_point_existing_remote() {
@@ -30,21 +30,20 @@ fn add_start_point_existing_remote() {
         .status_checked()
         .unwrap();
 
-    // We get a checkout for the remote-tracking branch!
-    prole.assert_contents(&[(
-        "my-repo/doggy/README.md",
-        expect![[r#"
-            softy pup
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/doggy").unwrap(), "puppy");
-
-    // We're tracking the remote branch we expect.
-    assert_eq!(
-        prole
-            .upstream_for_branch_in("my-repo/doggy", "puppy")
-            .unwrap(),
-        "origin/puppy"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("doggy")
+                .branch("puppy")
+                .upstream("origin/puppy")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        softy pup
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/add_start_point_new_local.rs
+++ b/tests/add_start_point_new_local.rs
@@ -1,7 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use pretty_assertions::assert_eq;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn add_start_point_new_local() {
@@ -23,12 +23,21 @@ fn add_start_point_new_local() {
         .status_checked()
         .unwrap();
 
-    prole.assert_contents(&[(
-        "my-repo/doggy/README.md",
-        expect![[r#"
-            soft cutie
-        "#]],
-    )]);
-
-    assert_eq!(prole.current_branch_in("my-repo/doggy").unwrap(), "doggy");
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("puppy"),
+            WorktreeState::new("doggy")
+                .branch("doggy")
+                // Should it have an upstream though...?
+                .no_upstream()
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        soft cutie
+                    "#]],
+                ),
+        ])
+        .assert();
 }

--- a/tests/clone_simple.rs
+++ b/tests/clone_simple.rs
@@ -1,6 +1,7 @@
 use command_error::CommandExt;
 use expect_test::expect;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn clone_simple() {
@@ -12,27 +13,16 @@ fn clone_simple() {
         .status_checked()
         .unwrap();
 
-    prole.assert_exists(&[
-        "my-repo",
-        "my-repo/.git",
-        "my-repo/main",
-        "my-repo/main/README.md",
-    ]);
-
-    assert_eq!(
-        prole
-            .git("my-repo/.git")
-            .config()
-            .get("core.bare")
-            .unwrap()
-            .unwrap(),
-        "true"
-    );
-
-    prole.assert_contents(&[(
-        "my-repo/main/README.md",
-        expect![[r#"
-            puppy doggy
-        "#]],
-    )]);
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main").file(
+                "README.md",
+                expect![[r#"
+                        puppy doggy
+                    "#]],
+            ),
+        ])
+        .assert();
 }

--- a/tests/config_copy_untracked.rs
+++ b/tests/config_copy_untracked.rs
@@ -2,6 +2,7 @@ use command_error::CommandExt;
 use expect_test::expect;
 use miette::IntoDiagnostic;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn config_copy_untracked() -> miette::Result<()> {
@@ -26,18 +27,27 @@ fn config_copy_untracked() -> miette::Result<()> {
         .status_checked()
         .into_diagnostic()?;
 
-    // The untracked file is not copied to the new worktree.
-    assert!(!prole
-        .path("my-repo/puppy/animal-facts.txt")
-        .try_exists()
-        .unwrap());
-
-    prole.assert_contents(&[(
-        "my-repo/main/animal-facts.txt",
-        expect![[r#"
-                puppy doggy
-            "#]],
-    )]);
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main")
+                .branch("main")
+                .file(
+                    "animal-facts.txt",
+                    expect![[r#"
+                        puppy doggy
+                    "#]],
+                )
+                .status(["?? animal-facts.txt"]),
+            WorktreeState::new("puppy")
+                .branch("puppy")
+                .upstream("main")
+                // The untracked file is not copied to the new worktree.
+                .no_file("animal-facts.txt")
+                .status([]),
+        ])
+        .assert();
 
     Ok(())
 }

--- a/tests/config_default_branches_default.rs
+++ b/tests/config_default_branches_default.rs
@@ -1,6 +1,7 @@
 use command_error::CommandExt;
 use miette::IntoDiagnostic;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn config_default_branches_default() -> miette::Result<()> {
@@ -27,22 +28,24 @@ fn config_default_branches_default() -> miette::Result<()> {
         .status_checked()
         .into_diagnostic()?;
 
-    // We can't find a default remote, so we look for a default branch. We pull up `master`
-    // because that's listed after `main`.
-    //
-    // Note: We can find a `master` branch on a remote even if it doesn't exist locally!
-    assert_eq!(prole.current_branch_in("my-repo/master")?, "master");
-    assert_eq!(
-        prole.upstream_for_branch_in("my-repo/master", "master")?,
-        "puppy/master"
-    );
-    // But we also get a checkout for the default HEAD on the remote when we clone, so that
-    // sticks around.
-    assert_eq!(prole.current_branch_in("my-repo/puppy")?, "puppy");
-    assert_eq!(
-        prole.upstream_for_branch_in("my-repo/puppy", "puppy")?,
-        "puppy/puppy"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            // We can't find a default remote, so we look for a default branch. We pull up `master`
+            // because that's listed after `main`.
+            //
+            // Note: We can find a `master` branch on a remote even if it doesn't exist locally!
+            WorktreeState::new("master")
+                .branch("master")
+                .upstream("puppy/trunk"),
+            // We also get a checkout for the default HEAD on the remote when we clone, so that
+            // sticks around.
+            WorktreeState::new("puppy")
+                .branch("puppy")
+                .upstream("puppy/puppy"),
+        ])
+        .assert();
 
     Ok(())
 }

--- a/tests/config_remotes.rs
+++ b/tests/config_remotes.rs
@@ -1,7 +1,9 @@
 use command_error::CommandExt;
+use expect_test::expect;
 use miette::IntoDiagnostic;
 use test_harness::setup_repo_multiple_remotes;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn config_remotes() -> miette::Result<()> {
@@ -23,9 +25,21 @@ fn config_remotes() -> miette::Result<()> {
         .status_checked()
         .into_diagnostic()?;
 
-    assert_eq!(prole.current_branch_in("my-repo/main")?, "main");
-    assert_eq!(prole.current_branch_in("my-repo/a")?, "a");
-    assert_eq!(prole.upstream_for_branch_in("my-repo/a", "a")?, "a/a");
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main")
+                .branch("main")
+                .upstream("origin/main"),
+            WorktreeState::new("a").branch("a").upstream("a/a").file(
+                "README.md",
+                expect![[r#"
+                    I am on branch a
+                "#]],
+            ),
+        ])
+        .assert();
 
     Ok(())
 }

--- a/tests/config_remotes_default.rs
+++ b/tests/config_remotes_default.rs
@@ -1,7 +1,9 @@
 use command_error::CommandExt;
+use expect_test::expect;
 use miette::IntoDiagnostic;
 use test_harness::setup_repo_multiple_remotes;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn convert_multiple_remotes() -> miette::Result<()> {
@@ -23,11 +25,24 @@ fn convert_multiple_remotes() -> miette::Result<()> {
         .status_checked()
         .into_diagnostic()?;
 
-    assert_eq!(prole.current_branch_in("my-repo/a")?, "a");
-    assert_eq!(
-        prole.upstream_for_branch_in("my-repo/a", "a")?,
-        "upstream/a"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main")
+                .branch("main")
+                .upstream("origin/main"),
+            WorktreeState::new("a")
+                .branch("a")
+                .upstream("upstream/a")
+                .file(
+                    "README.md",
+                    expect![[r#"
+                        I am on branch a
+                    "#]],
+                ),
+        ])
+        .assert();
 
     Ok(())
 }

--- a/tests/convert_multiple_remotes.rs
+++ b/tests/convert_multiple_remotes.rs
@@ -2,6 +2,7 @@ use command_error::CommandExt;
 use miette::IntoDiagnostic;
 use test_harness::setup_repo_multiple_remotes;
 use test_harness::GitProle;
+use test_harness::WorktreeState;
 
 #[test]
 fn convert_multiple_remotes() -> miette::Result<()> {
@@ -14,11 +15,15 @@ fn convert_multiple_remotes() -> miette::Result<()> {
         .status_checked()
         .into_diagnostic()?;
 
-    assert_eq!(prole.current_branch_in("my-repo/main")?, "main");
-    assert_eq!(
-        prole.upstream_for_branch_in("my-repo/main", "main")?,
-        "origin/main"
-    );
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main")
+                .branch("main")
+                .upstream("origin/main"),
+        ])
+        .assert();
 
     Ok(())
 }


### PR DESCRIPTION
This gives us a much more ergonomic and strict DSL for defining and checking the state of a repository.

For #21