### PR TITLE
Worktree parser: Get correct path for bare trees

### DIFF
--- a/test-harness/src/repo_state.rs
+++ b/test-harness/src/repo_state.rs
@@ -155,7 +155,7 @@ impl WorktreeState {
     ///
     /// This is used if a bare worktree named `.git` is present at the repository root.
     pub fn new_bare() -> Self {
-        Self::new("").bare()
+        Self::new(".git").bare()
     }
 
     /// This worktree is bare.


### PR DESCRIPTION
I needed to move this fix deeper into the parser to prevent the worktree converter from moving the `.git` dir into `.git/.git` (lol)