### PR TITLE
Update `command-error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
@@ -128,9 +128,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -138,36 +138,36 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size 0.3.0",
+ "terminal_size 0.4.0",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.5.26"
+version = "4.5.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0"
+checksum = "9646e2e245bf62f45d39a0f3f36f1171ad1ea0d6967fd114bca72cb02a8fcdfb"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.80",
 ]
 
 [[package]]
@@ -178,9 +178,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17415fd4dfbea46e3274fcd8d368284519b358654772afb700dc2e8d2b24eeb"
+checksum = "fbae9cbfdc5d4fa8711c09bd7b83f644cb48281ac35bf97af3e47b0675864bdf"
 dependencies = [
  "clap",
  "roff",
@@ -200,11 +200,12 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "command-error"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0ad563d6960fd12af36a93f24b381e58d6269e55e9617e4c7a3d0f05d7a9ca"
+checksum = "a388075d796717b179ed75638e4d48d27f492c406e6a3e129e0b727face726da"
 dependencies = [
  "dyn-clone",
+ "miette",
  "process-wrap",
  "shell-words",
  "tracing",
@@ -234,7 +235,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.80",
  "unicode-xid",
 ]
 
@@ -377,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -419,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -493,9 +494,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libredox"
@@ -591,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "option-ext"
@@ -669,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "pathdiff"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
 dependencies = [
  "camino",
 ]
@@ -694,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -724,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -744,14 +745,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -765,13 +766,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -782,9 +783,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "roff"
@@ -857,7 +858,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.80",
 ]
 
 [[package]]
@@ -956,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "e6e185e337f816bc8da115b8afcb3324006ccc82eeaddf35113888d3bd8e44ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1005,6 +1006,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
+dependencies = [
+ "rustix 0.38.37",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "test-harness"
 version = "0.1.0"
 dependencies = [
@@ -1046,22 +1057,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.80",
 ]
 
 [[package]]
@@ -1127,7 +1138,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.80",
 ]
 
 [[package]]
@@ -1197,15 +1208,15 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8-command"
@@ -1314,7 +1325,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.80",
 ]
 
 [[package]]
@@ -1325,7 +1336,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.80",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ camino = "1.1.6"
 clap = { version = "4.5.4", features = ["derive", "wrap_help", "env"] }
 clap_complete = "4.5.1"
 clap_mangen = { version = "0.2.20", optional = true }
-command-error = { version = "0.4.0", features = [ "tracing" ] }
+command-error = { version = "0.6.0", features = [ "tracing", "miette" ] }
 common-path = "1.0.0"
 derive_more = { version = "1.0.0", features = ["as_ref", "constructor", "deref", "deref_mut", "display", "from", "into"] }
 dirs = "5.0.1"

--- a/src/add.rs
+++ b/src/add.rs
@@ -160,7 +160,7 @@ impl<'a> WorktreePlan<'a> {
         if self.git.config.cli.dry_run {
             tracing::info!("$ {}", Utf8ProgramAndArgs::from(&command));
         } else {
-            command.status_checked().into_diagnostic()?;
+            command.status_checked()?;
             self.copy_untracked()?;
         }
         Ok(())

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -2,7 +2,6 @@ use std::process::Command;
 
 use command_error::CommandExt;
 use miette::miette;
-use miette::IntoDiagnostic;
 use which::which_global;
 
 use crate::app_git::AppGit;
@@ -31,8 +30,7 @@ pub fn clone(git: AppGit<'_>, args: CloneArgs) -> miette::Result<()> {
         Command::new("gh")
             .args(["repo", "clone", &args.repository, destination.as_str()])
             .args(args.clone_args)
-            .status_checked()
-            .into_diagnostic()?;
+            .status_checked()?;
     } else {
         // Test case: `clone_simple`.
         git.clone_repository(&args.repository, Some(&destination), &args.clone_args)?;

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use command_error::CommandExt;
 use command_error::OutputContext;
-use miette::IntoDiagnostic;
 use rustc_hash::FxHashSet as HashSet;
 use tracing::instrument;
 use utf8_command::Utf8Output;
@@ -51,13 +50,13 @@ impl<'a> GitBranch<'a> {
     /// Does a local branch exist?
     #[instrument(level = "trace")]
     pub fn exists_local(&self, branch: &str) -> miette::Result<bool> {
-        self.0
+        Ok(self
+            .0
             .command()
             .args(["show-ref", "--quiet", "--branches", branch])
             .output_checked_as(|context: OutputContext<Utf8Output>| {
                 Ok::<_, command_error::Error>(context.status().success())
-            })
-            .into_diagnostic()
+            })?)
     }
 
     /// Does the given branch name exist as a local branch, a unique remote branch, or neither?

--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use command_error::CommandExt;
 use command_error::OutputContext;
 use miette::miette;
-use miette::IntoDiagnostic;
 use tracing::instrument;
 use utf8_command::Utf8Output;
 
@@ -30,7 +29,8 @@ impl<'a> GitConfig<'a> {
         key: &str,
         parser: impl Fn(OutputContext<Utf8Output>, Option<String>) -> Result<R, command_error::Error>,
     ) -> miette::Result<R> {
-        self.0
+        Ok(self
+            .0
             .command()
             .args(["config", "get", "--null", key])
             .output_checked_as(|context: OutputContext<Utf8Output>| {
@@ -55,8 +55,7 @@ impl<'a> GitConfig<'a> {
                 } else {
                     Err(context.error())
                 }
-            })
-            .into_diagnostic()
+            })?)
     }
 
     /// Get a config setting by name.
@@ -91,8 +90,7 @@ impl<'a> GitConfig<'a> {
         self.0
             .command()
             .args(["config", "set", key, value])
-            .output_checked_utf8()
-            .into_diagnostic()?;
+            .output_checked_utf8()?;
         Ok(())
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -4,7 +4,6 @@ use std::process::Command;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use tracing::instrument;
 
 mod branch;
@@ -174,17 +173,14 @@ impl Git {
         if let Some(destination) = destination {
             command.arg(destination);
         }
-        command.status_checked().into_diagnostic()?;
+        command.status_checked()?;
         Ok(())
     }
 
     /// `git reset`.
     #[instrument(level = "trace")]
     pub fn reset(&self) -> miette::Result<()> {
-        self.command()
-            .arg("reset")
-            .output_checked_utf8()
-            .into_diagnostic()?;
+        self.command().arg("reset").output_checked_utf8()?;
         Ok(())
     }
 }

--- a/src/git/path.rs
+++ b/src/git/path.rs
@@ -5,7 +5,6 @@ use command_error::CommandExt;
 use command_error::OutputContext;
 use miette::miette;
 use miette::Context;
-use miette::IntoDiagnostic;
 use tracing::instrument;
 use utf8_command::Utf8Output;
 
@@ -47,7 +46,8 @@ impl<'a> GitPath<'a> {
     /// Check if we're inside a working tree.
     #[instrument(level = "trace")]
     pub fn is_inside_work_tree(&self) -> miette::Result<bool> {
-        self.0
+        Ok(self
+            .0
             .rev_parse_command()
             .arg("--is-inside-work-tree")
             .output_checked_as(|context: OutputContext<Utf8Output>| {
@@ -61,8 +61,7 @@ impl<'a> GitPath<'a> {
                         _ => Err(context.error_msg("Expected 'true' or 'false'")),
                     }
                 }
-            })
-            .into_diagnostic()
+            })?)
     }
 
     /// `git rev-parse --show-toplevel`
@@ -73,7 +72,6 @@ impl<'a> GitPath<'a> {
             .rev_parse_command()
             .arg("--show-toplevel")
             .output_checked_utf8()
-            .into_diagnostic()
             .wrap_err("Failed to get working directory of repository")?
             .stdout
             .trim()
@@ -83,22 +81,22 @@ impl<'a> GitPath<'a> {
     /// Get the `.git` directory path.
     #[expect(dead_code)] // #[instrument(level = "trace")]
     pub(crate) fn get_git_dir(&self) -> miette::Result<Utf8PathBuf> {
-        self.0
+        Ok(self
+            .0
             .rev_parse_command()
             .arg("--git-dir")
             .output_checked_utf8()
-            .into_diagnostic()
-            .map(|output| Utf8PathBuf::from(output.stdout.trim()))
+            .map(|output| Utf8PathBuf::from(output.stdout.trim()))?)
     }
 
     /// Get the common `.git` directory for all worktrees.
     #[instrument(level = "trace")]
     pub fn git_common_dir(&self) -> miette::Result<Utf8PathBuf> {
-        self.0
+        Ok(self
+            .0
             .rev_parse_command()
             .arg("--git-common-dir")
             .output_checked_utf8()
-            .into_diagnostic()
-            .map(|output| Utf8PathBuf::from(output.stdout.trim()))
+            .map(|output| Utf8PathBuf::from(output.stdout.trim()))?)
     }
 }

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -7,7 +7,6 @@ use camino::Utf8PathBuf;
 use command_error::CommandExt;
 use command_error::OutputContext;
 use miette::miette;
-use miette::IntoDiagnostic;
 use tracing::instrument;
 use utf8_command::Utf8Output;
 use winnow::combinator::eof;
@@ -38,7 +37,8 @@ impl<'a> GitStatus<'a> {
 
     #[instrument(level = "trace")]
     pub fn get(&self) -> miette::Result<Status> {
-        self.0
+        Ok(self
+            .0
             .command()
             .args(["status", "--porcelain=v1", "--ignored=traditional", "-z"])
             .output_checked_as(|context: OutputContext<Utf8Output>| {
@@ -47,8 +47,7 @@ impl<'a> GitStatus<'a> {
                 } else {
                     Err(context.error())
                 }
-            })
-            .into_diagnostic()
+            })?)
     }
 
     /// List untracked files and directories.
@@ -66,8 +65,7 @@ impl<'a> GitStatus<'a> {
                 "--directory",
                 "-z",
             ])
-            .output_checked_utf8()
-            .into_diagnostic()?
+            .output_checked_utf8()?
             .stdout
             .split('\0')
             .filter(|path| !path.is_empty())

--- a/src/git/worktree/mod.rs
+++ b/src/git/worktree/mod.rs
@@ -7,7 +7,6 @@ use camino::Utf8PathBuf;
 use command_error::CommandExt;
 use command_error::OutputContext;
 use miette::miette;
-use miette::IntoDiagnostic;
 use rustc_hash::FxHashMap as HashMap;
 use tap::Tap;
 use tracing::instrument;
@@ -69,7 +68,8 @@ impl<'a> GitWorktree<'a> {
     /// List Git worktrees.
     #[instrument(level = "trace")]
     pub fn list(&self) -> miette::Result<Worktrees> {
-        self.0
+        Ok(self
+            .0
             .command()
             .args(["worktree", "list", "--porcelain", "-z"])
             .output_checked_as(|context: OutputContext<Utf8Output>| {
@@ -85,15 +85,12 @@ impl<'a> GitWorktree<'a> {
                         }
                     }
                 }
-            })
-            .into_diagnostic()
+            })?)
     }
 
     #[instrument(level = "trace")]
     pub fn add(&self, path: &Utf8Path, options: &AddWorktreeOpts<'_>) -> miette::Result<()> {
-        self.add_command(path, options)
-            .status_checked()
-            .into_diagnostic()?;
+        self.add_command(path, options).status_checked()?;
         Ok(())
     }
 
@@ -134,8 +131,7 @@ impl<'a> GitWorktree<'a> {
             .command()
             .current_dir(from)
             .args(["worktree", "move", from.as_str(), to.as_str()])
-            .status_checked()
-            .into_diagnostic()?;
+            .status_checked()?;
         Ok(())
     }
 
@@ -148,8 +144,7 @@ impl<'a> GitWorktree<'a> {
             .command()
             .args(["worktree", "repair"])
             .args(paths)
-            .output_checked_utf8()
-            .into_diagnostic()?;
+            .output_checked_utf8()?;
         Ok(())
     }
 

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 camino = "1.1.9"
 clonable-command = "0.2.0"
-command-error = "0.4.1"
+command-error = { version = "0.6.0", features = [ "tracing", "miette" ] }
 itertools = "0.13.0"
 miette = { version = "*", default-features = false, features = ["fancy-no-backtrace"] }
 regex = "*"

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -122,8 +122,7 @@ impl GitProle {
         self.any_command("bash")
             .arg("--norc")
             .arg(tempfile.as_ref())
-            .status_checked()
-            .into_diagnostic()?;
+            .status_checked()?;
         Ok(())
     }
 
@@ -168,7 +167,6 @@ impl GitProle {
             .current_dir(self.path(path))
             .arg("convert")
             .output_checked_utf8()
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to convert {path} to a worktree checkout"))?;
 
         Ok(())

--- a/tests/add_copy_untracked_broken_symlink.rs
+++ b/tests/add_copy_untracked_broken_symlink.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -20,8 +19,7 @@ fn add_copy_untracked_broken_symlink() -> miette::Result<()> {
     prole
         .cd_cmd("my-repo/main")
         .args(["add", "puppy"])
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/config_copy_untracked.rs
+++ b/tests/config_copy_untracked.rs
@@ -1,6 +1,5 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -24,8 +23,7 @@ fn config_copy_untracked() -> miette::Result<()> {
     prole
         .cd_cmd("my-repo/main")
         .args(["add", "puppy"])
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/config_copy_untracked_default.rs
+++ b/tests/config_copy_untracked_default.rs
@@ -1,6 +1,5 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -18,8 +17,7 @@ fn config_copy_untracked_default() -> miette::Result<()> {
     prole
         .cd_cmd("my-repo/main")
         .args(["add", "puppy"])
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     // The untracked file is copied to the new worktree.
 

--- a/tests/config_default_branches.rs
+++ b/tests/config_default_branches.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -31,11 +30,7 @@ fn config_default_branches() -> miette::Result<()> {
         "#,
     )?;
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/config_default_branches_default.rs
+++ b/tests/config_default_branches_default.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -22,11 +21,7 @@ fn config_default_branches_default() -> miette::Result<()> {
         git remote rename origin puppy
         ")?;
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/config_remotes.rs
+++ b/tests/config_remotes.rs
@@ -1,6 +1,5 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use miette::IntoDiagnostic;
 use test_harness::setup_repo_multiple_remotes;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
@@ -19,11 +18,7 @@ fn config_remotes() -> miette::Result<()> {
         "#,
     )?;
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/config_remotes_default.rs
+++ b/tests/config_remotes_default.rs
@@ -1,6 +1,5 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use miette::IntoDiagnostic;
 use test_harness::setup_repo_multiple_remotes;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
@@ -19,11 +18,7 @@ fn config_remotes_default() -> miette::Result<()> {
     //
     // The default config says `upstream` is more important than `origin`, so we use that!
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_bare_dot_git.rs
+++ b/tests/convert_bare_dot_git.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -24,8 +23,7 @@ fn convert_bare_dot_git() -> miette::Result<()> {
     prole
         .cd_cmd("my-repo/main")
         .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_bare_ends_with_dot_git.rs
+++ b/tests/convert_bare_ends_with_dot_git.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -24,8 +23,7 @@ fn convert_bare_ends_with_dot_git() -> miette::Result<()> {
     prole
         .cd_cmd("my-repo.git")
         .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_bare_no_dot.rs
+++ b/tests/convert_bare_no_dot.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -21,11 +20,7 @@ fn convert_bare_no_dot() -> miette::Result<()> {
         git worktree add --detach ../doggy
         "#)?;
 
-    prole
-        .cd_cmd("main")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("main").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_bare_starts_with_dot.rs
+++ b/tests/convert_bare_starts_with_dot.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -24,8 +23,7 @@ fn convert_bare_starts_with_dot() -> miette::Result<()> {
     prole
         .cd_cmd("my-repo/main")
         .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_common_parent.rs
+++ b/tests/convert_common_parent.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -17,8 +16,7 @@ fn convert_common_parent() -> miette::Result<()> {
     prole
         .cd_cmd("my-prefix/my-repo")
         .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     prole
         .repo_state("my-prefix")

--- a/tests/convert_common_parent_extra_dotfiles.rs
+++ b/tests/convert_common_parent_extra_dotfiles.rs
@@ -1,6 +1,5 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -22,8 +21,7 @@ fn convert_common_parent_extra_dotfiles() -> miette::Result<()> {
     prole
         .cd_cmd("my-prefix/my-repo")
         .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     prole
         .repo_state("my-prefix")

--- a/tests/convert_common_parent_extra_files.rs
+++ b/tests/convert_common_parent_extra_files.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -21,8 +20,7 @@ fn convert_common_parent_extra_files() -> miette::Result<()> {
     prole
         .cd_cmd("my-prefix/my-repo")
         .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     prole
         .repo_state("my-prefix/my-repo")

--- a/tests/convert_common_prefix.rs
+++ b/tests/convert_common_prefix.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -19,8 +18,7 @@ fn convert_common_prefix() -> miette::Result<()> {
     prole
         .cd_cmd("my-prefix/my-repo")
         .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     prole
         .repo_state("my-prefix/my-repo")

--- a/tests/convert_default_branch_checked_out.rs
+++ b/tests/convert_default_branch_checked_out.rs
@@ -1,6 +1,5 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -9,11 +8,7 @@ fn convert_default_branch_checked_out() -> miette::Result<()> {
     let prole = GitProle::new()?;
     prole.setup_repo("my-repo")?;
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_destination_explicit.rs
+++ b/tests/convert_destination_explicit.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -11,8 +10,7 @@ fn convert_destination_explicit() -> miette::Result<()> {
     prole
         .cd_cmd("my-repo")
         .args(["convert", "../puppy"])
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     prole.sh("ls -la && ls -la puppy")?;
 

--- a/tests/convert_detached_head.rs
+++ b/tests/convert_detached_head.rs
@@ -1,7 +1,6 @@
 use command_error::CommandExt;
 use expect_test::expect;
 use git_prole::HeadKind;
-use miette::IntoDiagnostic;
 use pretty_assertions::assert_eq;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
@@ -16,11 +15,7 @@ fn convert_detached_head() -> miette::Result<()> {
         git switch --detach
         ")?;
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     assert_eq!(
         prole.git("my-repo/main").refs().head_kind()?,

--- a/tests/convert_explicit_default_branch.rs
+++ b/tests/convert_explicit_default_branch.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::setup_repo_multiple_remotes;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
@@ -17,8 +16,7 @@ fn convert_explicit_default_branch() -> miette::Result<()> {
     prole
         .cd_cmd("my-repo")
         .args(["convert", "--default-branch", "a/a"])
-        .status_checked()
-        .into_diagnostic()?;
+        .status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_multiple_remotes.rs
+++ b/tests/convert_multiple_remotes.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::setup_repo_multiple_remotes;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
@@ -9,11 +8,7 @@ fn convert_multiple_remotes() -> miette::Result<()> {
     let prole = GitProle::new()?;
     setup_repo_multiple_remotes(&prole, "my-remotes/my-repo", "my-repo")?;
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_multiple_worktrees.rs
+++ b/tests/convert_multiple_worktrees.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -16,11 +15,7 @@ fn convert_multiple_worktrees() -> miette::Result<()> {
         git worktree add ../doggy
         ")?;
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_no_local_default_branch.rs
+++ b/tests/convert_no_local_default_branch.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::setup_repo_multiple_remotes;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
@@ -15,11 +14,7 @@ fn convert_no_local_default_branch() -> miette::Result<()> {
         git branch -D main
     "#)?;
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_no_op.rs
+++ b/tests/convert_no_op.rs
@@ -1,5 +1,4 @@
 use command_error::CommandExt;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -27,8 +26,7 @@ fn convert_no_op() -> miette::Result<()> {
     let output = prole
         .cd_cmd("my-repo")
         .arg("convert")
-        .output_checked_utf8()
-        .into_diagnostic()?;
+        .output_checked_utf8()?;
 
     assert!(
         output.stderr.contains("is already a worktree repository"),

--- a/tests/convert_non_default_branch_checked_out.rs
+++ b/tests/convert_non_default_branch_checked_out.rs
@@ -1,6 +1,5 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -16,11 +15,7 @@ fn convert_non_default_branch_checked_out() -> miette::Result<()> {
         git commit -am 'cooler readme'
         ")?;
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_uncommitted_changes.rs
+++ b/tests/convert_uncommitted_changes.rs
@@ -1,6 +1,5 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -23,11 +22,7 @@ fn convert_uncommitted_changes() -> miette::Result<()> {
             .status(["M  README.md"])])
         .assert();
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")

--- a/tests/convert_unstaged_changes.rs
+++ b/tests/convert_unstaged_changes.rs
@@ -1,6 +1,5 @@
 use command_error::CommandExt;
 use expect_test::expect;
-use miette::IntoDiagnostic;
 use test_harness::GitProle;
 use test_harness::WorktreeState;
 
@@ -22,11 +21,7 @@ fn convert_unstaged_changes() -> miette::Result<()> {
             .status([" M README.md"])])
         .assert();
 
-    prole
-        .cd_cmd("my-repo")
-        .arg("convert")
-        .status_checked()
-        .into_diagnostic()?;
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
 
     prole
         .repo_state("my-repo")


### PR DESCRIPTION
- This adds the `current_dir` (and env variables) to commands when they're logged
- This also lets us remove an enormous amount of `.into_diagnostic()` calls