### PR TITLE
Fix `add` in the container directory

### DIFF
--- a/src/app_git.rs
+++ b/src/app_git.rs
@@ -3,7 +3,6 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 
 use camino::Utf8PathBuf;
-use miette::miette;
 use rustc_hash::FxHashSet as HashSet;
 use tracing::instrument;
 
@@ -11,6 +10,8 @@ use crate::config::Config;
 use crate::git::BranchRef;
 use crate::git::Git;
 use crate::git::LocalBranchRef;
+use crate::Worktree;
+use crate::Worktrees;
 
 /// A [`Git`] with borrowed [`Config`].
 #[derive(Clone)]
@@ -98,12 +99,13 @@ impl<'a> AppGit<'a> {
 
     /// Get the user's preferred default branch.
     #[instrument(level = "trace")]
-    pub fn preferred_branch(&self) -> miette::Result<BranchRef> {
+    pub fn preferred_branch(&self) -> miette::Result<Option<BranchRef>> {
         if let Some(default_remote) = self.preferred_remote()? {
             return self
                 .remote()
                 .default_branch(&default_remote)
-                .map(BranchRef::from);
+                .map(BranchRef::from)
+                .map(Some);
         }
 
         let preferred_branches = self.config.file.default_branches();
@@ -111,16 +113,91 @@ impl<'a> AppGit<'a> {
         for preferred_branch in preferred_branches {
             let preferred_branch = LocalBranchRef::new(preferred_branch);
             if all_branches.contains(&preferred_branch) {
-                return Ok(preferred_branch.into());
+                return Ok(Some(preferred_branch.into()));
             } else if let Some(remote_branch) =
                 self.remote().for_branch(preferred_branch.branch_name())?
             {
-                return Ok(remote_branch.into());
+                return Ok(Some(remote_branch.into()));
             }
         }
 
-        Err(miette!(
-            "No default branch found; specify a `--default-branch` to check out"
-        ))
+        Ok(None)
+    }
+
+    /// Get the worktree for the preferred branch, if any.
+    #[instrument(level = "trace")]
+    pub fn preferred_branch_worktree(
+        &self,
+        preferred_branch: Option<&BranchRef>,
+        worktrees: Option<&Worktrees>,
+    ) -> miette::Result<Option<Worktree>> {
+        let worktrees = match worktrees {
+            Some(worktrees) => worktrees,
+            None => &self.worktree().list()?,
+        };
+        let preferred_branch = match preferred_branch {
+            Some(preferred_branch) => preferred_branch,
+            None => &match self.preferred_branch()? {
+                Some(preferred_branch) => preferred_branch,
+                None => {
+                    return Ok(None);
+                }
+            },
+        };
+
+        // TODO: Check for branch with the default as an upstream as well?
+        Ok(worktrees.for_branch(&preferred_branch.as_local()).cloned())
+    }
+
+    /// Get the path to _some_ worktree.
+    ///
+    /// This prefers, in order:
+    /// 1. The current worktree.
+    /// 2. The worktree for the default branch.
+    /// 3. Any non-bare worktree.
+    /// 4. A bare worktree.
+    #[instrument(level = "trace")]
+    pub fn some_worktree(&self) -> miette::Result<Utf8PathBuf> {
+        if self.worktree().is_inside()? {
+            tracing::debug!("Inside worktree");
+            // Test: `add_by_path`
+            return self.worktree().root();
+        }
+        let worktrees = self.worktree().list()?;
+
+        if let Some(worktree) = self.preferred_branch_worktree(None, Some(&worktrees))? {
+            tracing::debug!(%worktree, "Found worktree for preferred branch");
+            // Test: `add_from_container`
+            return Ok(worktree.path);
+        }
+
+        tracing::debug!("No worktree for preferred branch");
+
+        if worktrees.main().head.is_bare() && worktrees.len() > 1 {
+            // Find a non-bare worktree.
+            //
+            // Test: `add_from_container_no_default_branch`
+            let worktree = worktrees
+                .into_iter()
+                .find(|(_path, worktree)| !worktree.head.is_bare())
+                .expect("Only one worktree can be bare")
+                .0;
+
+            tracing::debug!(%worktree, "Found non-bare worktree");
+            return Ok(worktree);
+        }
+
+        // Otherwise, get the main worktree.
+        // Either the main worktree is bare and there's no other worktrees, or the main
+        // worktree is not bare.
+        //
+        // Note: If the main worktree isn't bare, there's no way to run Git commands
+        // without being in a worktree. IDK I guess you can probably do something silly
+        // with separating the Git directory and the worktree but like, why.
+        //
+        // Tests:
+        // - `add_from_bare_no_worktrees`
+        tracing::debug!("Non-bare main worktree or no non-bare worktrees");
+        Ok(worktrees.main_path().to_owned())
     }
 }

--- a/src/copy_dir.rs
+++ b/src/copy_dir.rs
@@ -12,7 +12,10 @@ use tracing::instrument;
 macro_rules! push_error {
     ($expr:expr, $vec:ident) => {
         match $expr {
-            Err(error) => $vec.push(error),
+            Err(error) => {
+                tracing::debug!("{error}");
+                $vec.push(error)
+            }
             Ok(_) => {}
         }
     };

--- a/src/git/worktree/parse.rs
+++ b/src/git/worktree/parse.rs
@@ -129,6 +129,16 @@ impl Deref for Worktrees {
     }
 }
 
+impl IntoIterator for Worktrees {
+    type Item = (Utf8PathBuf, Worktree);
+
+    type IntoIter = std::collections::hash_map::IntoIter<Utf8PathBuf, Worktree>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
 impl Display for Worktrees {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut trees = self.values().peekable();

--- a/tests/add_from_bare_no_worktrees.rs
+++ b/tests/add_from_bare_no_worktrees.rs
@@ -1,0 +1,43 @@
+use command_error::CommandExt;
+use test_harness::GitProle;
+use test_harness::WorktreeState;
+
+#[test]
+fn add_from_bare_no_worktrees() -> miette::Result<()> {
+    let prole = GitProle::new()?;
+    prole.setup_worktree_repo("my-repo")?;
+
+    prole.write_config(
+        r#"
+        default_branches = []
+        "#,
+    )?;
+
+    prole.sh(r#"
+        cd my-repo/main || exit
+        git switch -c puppy
+        git branch -D main
+        git worktree remove .
+        cd ../.git || exit
+        # `git checkout` and `git switch` don't work in a bare repository.
+        # See: https://stackoverflow.com/a/3302018
+        git symbolic-ref HEAD refs/heads/puppy
+    "#)?;
+
+    // We can add a worktree from the container directory (outside of any working tree but
+    // "within" the repo as far as Git is concerned).
+    prole
+        .cd_cmd("my-repo")
+        .args(["add", "doggy", "HEAD"])
+        .status_checked()?;
+
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("doggy").branch("doggy"),
+        ])
+        .assert();
+
+    Ok(())
+}

--- a/tests/add_from_container.rs
+++ b/tests/add_from_container.rs
@@ -1,0 +1,27 @@
+use command_error::CommandExt;
+use test_harness::GitProle;
+use test_harness::WorktreeState;
+
+#[test]
+fn add_from_container() -> miette::Result<()> {
+    let prole = GitProle::new()?;
+    prole.setup_worktree_repo("my-repo")?;
+
+    // We can add a worktree from the container directory (outside of any working tree but
+    // "within" the repo as far as Git is concerned).
+    prole
+        .cd_cmd("my-repo")
+        .args(["add", "puppy"])
+        .status_checked()?;
+
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("puppy").branch("puppy").upstream("main"),
+        ])
+        .assert();
+
+    Ok(())
+}

--- a/tests/add_from_container_no_default_branch.rs
+++ b/tests/add_from_container_no_default_branch.rs
@@ -1,0 +1,49 @@
+use command_error::CommandExt;
+use expect_test::expect;
+use test_harness::GitProle;
+use test_harness::WorktreeState;
+
+#[test]
+fn add_from_container_no_default_branch() -> miette::Result<()> {
+    let prole = GitProle::new()?;
+    prole.setup_worktree_repo("my-repo")?;
+
+    prole.write_config(
+        r#"
+        default_branches = []
+        "#,
+    )?;
+
+    prole.sh(r#"
+        cd my-repo || exit
+        git worktree move main puppy
+        cd puppy || exit
+        git switch -c puppy
+        git branch -D main
+        echo puppyyyy > puppy-file
+    "#)?;
+
+    // We can add a worktree from the container directory (outside of any working tree but
+    // "within" the repo as far as Git is concerned).
+    prole
+        .cd_cmd("my-repo")
+        .args(["add", "doggy", "@"])
+        .status_checked()?;
+
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("puppy").branch("puppy"),
+            // Copied from first non-bare worktree even if no default is found.
+            WorktreeState::new("doggy").branch("doggy").file(
+                "puppy-file",
+                expect![[r#"
+                    puppyyyy
+                "#]],
+            ),
+        ])
+        .assert();
+
+    Ok(())
+}

--- a/tests/add_from_non_worktree_repo.rs
+++ b/tests/add_from_non_worktree_repo.rs
@@ -1,0 +1,46 @@
+use command_error::CommandExt;
+use expect_test::expect;
+use test_harness::GitProle;
+use test_harness::WorktreeState;
+
+#[test]
+fn add_from_non_worktree_repo() -> miette::Result<()> {
+    let prole = GitProle::new()?;
+    prole.setup_repo("my-repo")?;
+
+    prole.write_config(
+        r#"
+        default_branches = []
+        "#,
+    )?;
+
+    prole.sh(r#"
+        cd my-repo || exit
+        git switch -c puppy
+        git branch -D main
+        echo puppyyyy > puppy-file
+    "#)?;
+
+    // We can add a worktree from the container directory (outside of any working tree but
+    // "within" the repo as far as Git is concerned).
+    prole
+        .cd_cmd("my-repo")
+        .args(["add", "doggy", "@"])
+        .status_checked()?;
+
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new("").branch("puppy"),
+            // Copied from first non-bare worktree even if no default is found.
+            WorktreeState::new("../doggy").branch("doggy").file(
+                "puppy-file",
+                expect![[r#"
+                    puppyyyy
+                "#]],
+            ),
+        ])
+        .assert();
+
+    Ok(())
+}

--- a/tests/convert_bare_dot_git_from_parent.rs
+++ b/tests/convert_bare_dot_git_from_parent.rs
@@ -1,0 +1,36 @@
+use command_error::CommandExt;
+use test_harness::GitProle;
+use test_harness::WorktreeState;
+
+#[test]
+fn convert_bare_dot_git_from_parent() -> miette::Result<()> {
+    let prole = GitProle::new()?;
+    prole.sh(r#"
+        mkdir -p my-repo/.git
+        cd my-repo/.git || exit
+        git init --bare
+
+        git worktree add ../main
+        cd ../main || exit
+        echo "puppy doggy" > README.md 
+        git add .
+        git commit -m "Initial commit"
+
+        git worktree add ../puppy
+        git worktree add --detach ../doggy
+        "#)?;
+
+    prole.cd_cmd("my-repo").arg("convert").status_checked()?;
+
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("puppy").branch("puppy"),
+            WorktreeState::new("doggy").detached("4023d080"),
+        ])
+        .assert();
+
+    Ok(())
+}

--- a/tests/convert_from_bare.rs
+++ b/tests/convert_from_bare.rs
@@ -1,0 +1,39 @@
+use command_error::CommandExt;
+use test_harness::GitProle;
+use test_harness::WorktreeState;
+
+#[test]
+fn convert_from_bare() -> miette::Result<()> {
+    let prole = GitProle::new()?;
+    prole.sh(r#"
+        mkdir -p my-repo/.git
+        cd my-repo/.git || exit
+        git init --bare
+
+        git worktree add ../main
+        cd ../main || exit
+        echo "puppy doggy" > README.md 
+        git add .
+        git commit -m "Initial commit"
+
+        git worktree add ../puppy
+        git worktree add --detach ../doggy
+        "#)?;
+
+    prole
+        .cd_cmd("my-repo/.git")
+        .arg("convert")
+        .status_checked()?;
+
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            WorktreeState::new("puppy").branch("puppy"),
+            WorktreeState::new("doggy").detached("4023d080"),
+        ])
+        .assert();
+
+    Ok(())
+}


### PR DESCRIPTION
Git recognizes the parent of the bare .git as a repo, but previously `git-prole` would run `git rev-parse --show-toplevel`, which fails.