### PR TITLE
Add `GitLike`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use calm_io::stdout;
+use camino::Utf8PathBuf;
 use clap::CommandFactory;
 use miette::miette;
 use miette::IntoDiagnostic;
@@ -23,7 +24,7 @@ impl App {
         Self { config }
     }
 
-    pub fn git(&self) -> miette::Result<AppGit<'_>> {
+    pub fn git(&self) -> miette::Result<AppGit<'_, Utf8PathBuf>> {
         Ok(Git::from_current_dir()?.with_config(&self.config))
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,22 @@ pub struct Cli {
     pub command: Command,
 }
 
+impl Cli {
+    /// A fake stub CLI for testing.
+    #[cfg(test)]
+    pub fn test_stub() -> Self {
+        Self {
+            log: "info".to_owned(),
+            dry_run: false,
+            config: None,
+            command: Command::Convert(ConvertArgs {
+                default_branch: None,
+                destination: None,
+            }),
+        }
+    }
+}
+
 #[allow(rustdoc::bare_urls)]
 #[derive(Debug, Clone, Subcommand)]
 pub enum Command {

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -7,21 +7,29 @@ use tracing::instrument;
 use utf8_command::Utf8Output;
 
 use super::BranchRef;
-use super::Git;
+use super::GitLike;
 use super::LocalBranchRef;
 
 /// Git methods for dealing with worktrees.
 #[repr(transparent)]
-pub struct GitBranch<'a>(&'a Git);
+pub struct GitBranch<'a, G>(&'a G);
 
-impl Debug for GitBranch<'_> {
+impl<G> Debug for GitBranch<'_, G>
+where
+    G: GitLike,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(self.0, f)
+        f.debug_tuple("GitBranch")
+            .field(&self.0.get_current_dir().as_ref())
+            .finish()
     }
 }
 
-impl<'a> GitBranch<'a> {
-    pub fn new(git: &'a Git) -> Self {
+impl<'a, G> GitBranch<'a, G>
+where
+    G: GitLike,
+{
+    pub fn new(git: &'a G) -> Self {
         Self(git)
     }
 

--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -6,20 +6,28 @@ use miette::miette;
 use tracing::instrument;
 use utf8_command::Utf8Output;
 
-use super::Git;
+use super::GitLike;
 
 /// Git methods for dealing with config.
 #[repr(transparent)]
-pub struct GitConfig<'a>(&'a Git);
+pub struct GitConfig<'a, G>(&'a G);
 
-impl Debug for GitConfig<'_> {
+impl<G> Debug for GitConfig<'_, G>
+where
+    G: GitLike,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(self.0, f)
+        f.debug_tuple("GitConfig")
+            .field(&self.0.get_current_dir().as_ref())
+            .finish()
     }
 }
 
-impl<'a> GitConfig<'a> {
-    pub fn new(git: &'a Git) -> Self {
+impl<'a, G> GitConfig<'a, G>
+where
+    G: GitLike,
+{
+    pub fn new(git: &'a G) -> Self {
         Self(git)
     }
 

--- a/src/git/git_like.rs
+++ b/src/git/git_like.rs
@@ -1,0 +1,71 @@
+use std::process::Command;
+
+use camino::Utf8Path;
+
+use super::Git;
+use super::GitBranch;
+use super::GitConfig;
+use super::GitPath;
+use super::GitRefs;
+use super::GitRemote;
+use super::GitStatus;
+use super::GitWorktree;
+
+pub trait GitLike: Sized {
+    type CurrentDir: AsRef<Utf8Path>;
+
+    fn as_git(&self) -> &Git<Self::CurrentDir>;
+
+    #[inline]
+    fn get_current_dir(&self) -> &Self::CurrentDir {
+        self.as_git().get_current_dir()
+    }
+
+    /// Get a `git` command.
+    #[inline]
+    fn command(&self) -> Command {
+        self.as_git().command()
+    }
+
+    /// Methods for dealing with Git remotes.
+    #[inline]
+    fn remote(&self) -> GitRemote<'_, Self> {
+        GitRemote::new(self)
+    }
+
+    /// Methods for dealing with Git remotes.
+    #[inline]
+    fn path(&self) -> GitPath<'_, Self> {
+        GitPath::new(self)
+    }
+
+    /// Methods for dealing with Git remotes.
+    #[inline]
+    fn worktree(&self) -> GitWorktree<'_, Self> {
+        GitWorktree::new(self)
+    }
+
+    /// Methods for dealing with Git refs.
+    #[inline]
+    fn refs(&self) -> GitRefs<'_, Self> {
+        GitRefs::new(self)
+    }
+
+    /// Methods for dealing with Git statuses and the working tree.
+    #[inline]
+    fn status(&self) -> GitStatus<'_, Self> {
+        GitStatus::new(self)
+    }
+
+    /// Methods for dealing with Git statuses and the working tree.
+    #[inline]
+    fn config(&self) -> GitConfig<'_, Self> {
+        GitConfig::new(self)
+    }
+
+    /// Methods for dealing with Git statuses and the working tree.
+    #[inline]
+    fn branch(&self) -> GitBranch<'_, Self> {
+        GitBranch::new(self)
+    }
+}

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -13,23 +13,31 @@ use winnow::token::take_till;
 use winnow::PResult;
 use winnow::Parser;
 
-use super::Git;
+use super::GitLike;
 use super::LocalBranchRef;
 use super::Ref;
 use super::RemoteBranchRef;
 
 /// Git methods for dealing with remotes.
 #[repr(transparent)]
-pub struct GitRemote<'a>(&'a Git);
+pub struct GitRemote<'a, G>(&'a G);
 
-impl Debug for GitRemote<'_> {
+impl<G> Debug for GitRemote<'_, G>
+where
+    G: GitLike,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(self.0, f)
+        f.debug_tuple("GitRemote")
+            .field(&self.0.get_current_dir().as_ref())
+            .finish()
     }
 }
 
-impl<'a> GitRemote<'a> {
-    pub fn new(git: &'a Git) -> Self {
+impl<'a, G> GitRemote<'a, G>
+where
+    G: GitLike,
+{
+    pub fn new(git: &'a G) -> Self {
         Self(git)
     }
 

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -18,20 +18,28 @@ use winnow::Parser;
 
 use crate::parse::till_null;
 
-use super::Git;
+use super::GitLike;
 
 /// Git methods for dealing with statuses and the working tree.
 #[repr(transparent)]
-pub struct GitStatus<'a>(&'a Git);
+pub struct GitStatus<'a, G>(&'a G);
 
-impl Debug for GitStatus<'_> {
+impl<G> Debug for GitStatus<'_, G>
+where
+    G: GitLike,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(self.0, f)
+        f.debug_tuple("GitStatus")
+            .field(&self.0.get_current_dir().as_ref())
+            .finish()
     }
 }
 
-impl<'a> GitStatus<'a> {
-    pub fn new(git: &'a Git) -> Self {
+impl<'a, G> GitStatus<'a, G>
+where
+    G: GitLike,
+{
+    pub fn new(git: &'a G) -> Self {
         Self(git)
     }
 

--- a/src/git/worktree/parse.rs
+++ b/src/git/worktree/parse.rs
@@ -20,9 +20,9 @@ use winnow::stream::Stream as _;
 use winnow::PResult;
 use winnow::Parser;
 
+use crate::git::GitLike;
 use crate::parse::till_null;
 use crate::CommitHash;
-use crate::Git;
 use crate::LocalBranchRef;
 use crate::PathDisplay;
 use crate::Ref;
@@ -91,7 +91,7 @@ impl Worktrees {
         Ok(worktrees)
     }
 
-    pub fn parse(git: &Git, input: &str) -> miette::Result<Self> {
+    pub fn parse(git: &impl GitLike, input: &str) -> miette::Result<Self> {
         let mut ret = Self::parser.parse(input).map_err(|err| miette!("{err}"))?;
 
         if ret.main().head.is_bare() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub use git::CommitHash;
 pub use git::Git;
 pub use git::GitBranch;
 pub use git::GitConfig;
+pub use git::GitLike;
 pub use git::GitPath;
 pub use git::GitRefs;
 pub use git::GitRemote;

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -127,7 +127,7 @@ impl GitProle {
     }
 
     #[track_caller]
-    pub fn git(&self, directory: &str) -> Git {
+    pub fn git(&self, directory: &str) -> Git<Utf8PathBuf> {
         let path = self.path(directory);
         if !path.exists() {
             panic!("A test requested a Git interface for a nonexistent path: {directory}");

--- a/tests/convert_detached_head.rs
+++ b/tests/convert_detached_head.rs
@@ -1,5 +1,6 @@
 use command_error::CommandExt;
 use expect_test::expect;
+use git_prole::GitLike;
 use git_prole::HeadKind;
 use pretty_assertions::assert_eq;
 use test_harness::GitProle;


### PR DESCRIPTION
- This adds a bunch of parameterization to the Git interface:
  - `Git` is now parameterized by the type of the type of the current dir path. This means we don't have to clone a path to execute a Git command in another directory as often.
- A new `GitLike` trait represents types that can be dereferenced into a `&Git`. This makes it possible to parameterize types like `GitWorktree` by the type of git wrapper they contain, making it possible to write methods that are only available for `AppGit`.