### PR TITLE
Use `FxHash{Map,Set}` unaliased

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -8,7 +8,7 @@ use miette::miette;
 use miette::IntoDiagnostic;
 use owo_colors::OwoColorize;
 use owo_colors::Stream;
-use rustc_hash::FxHashSet as HashSet;
+use rustc_hash::FxHashSet;
 use tracing::instrument;
 
 use crate::app_git::AppGit;
@@ -303,7 +303,7 @@ where
                 .iter()
                 .map(|plan| plan.name.to_owned())
                 .collect(),
-            directory_names: &HashSet::from_iter([destination_name]),
+            directory_names: &FxHashSet::from_iter([destination_name]),
         })?;
 
         tracing::debug!(

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use camino::Utf8Path;
 use command_error::CommandExt;
 use command_error::OutputContext;
-use rustc_hash::FxHashSet as HashSet;
+use rustc_hash::FxHashSet;
 use tracing::instrument;
 use utf8_command::Utf8Output;
 
@@ -38,24 +38,24 @@ where
 
     /// Lists local branches.
     #[instrument(level = "trace")]
-    pub fn list_local(&self) -> miette::Result<HashSet<LocalBranchRef>> {
+    pub fn list_local(&self) -> miette::Result<FxHashSet<LocalBranchRef>> {
         self.0
             .refs()
             .for_each_ref(Some(&["refs/heads/**"]))?
             .into_iter()
             .map(LocalBranchRef::try_from)
-            .collect::<Result<HashSet<_>, _>>()
+            .collect::<Result<FxHashSet<_>, _>>()
     }
 
     /// Lists local and remote branches.
     #[instrument(level = "trace")]
-    pub fn list(&self) -> miette::Result<HashSet<BranchRef>> {
+    pub fn list(&self) -> miette::Result<FxHashSet<BranchRef>> {
         self.0
             .refs()
             .for_each_ref(Some(&["refs/heads/**", "refs/remotes/**"]))?
             .into_iter()
             .map(BranchRef::try_from)
-            .collect::<Result<HashSet<_>, _>>()
+            .collect::<Result<FxHashSet<_>, _>>()
     }
 
     /// Does a local branch exist?

--- a/src/git/worktree/mod.rs
+++ b/src/git/worktree/mod.rs
@@ -8,7 +8,7 @@ use command_error::CommandExt;
 use command_error::OutputContext;
 use miette::miette;
 use miette::Context;
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::FxHashMap;
 use tap::Tap;
 use tracing::instrument;
 use utf8_command::Utf8Output;
@@ -275,7 +275,7 @@ where
     pub fn resolve_unique_names(
         &self,
         opts: ResolveUniqueNameOpts<'_>,
-    ) -> miette::Result<HashMap<Utf8PathBuf, RenamedWorktree>> {
+    ) -> miette::Result<FxHashMap<Utf8PathBuf, RenamedWorktree>> {
         resolve_unique_names::resolve_unique_worktree_names(self.0, opts)
     }
 

--- a/src/git/worktree/parse.rs
+++ b/src/git/worktree/parse.rs
@@ -6,7 +6,7 @@ use camino::Utf8PathBuf;
 use miette::miette;
 use owo_colors::OwoColorize;
 use owo_colors::Stream;
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::FxHashMap;
 use winnow::combinator::alt;
 use winnow::combinator::cut_err;
 use winnow::combinator::eof;
@@ -37,7 +37,7 @@ pub struct Worktrees {
     /// case of a bare repository, _is_ a `.git` directory.
     pub(crate) main: Utf8PathBuf,
     /// A map from worktree paths to worktree information.
-    pub(crate) inner: HashMap<Utf8PathBuf, Worktree>,
+    pub(crate) inner: FxHashMap<Utf8PathBuf, Worktree>,
 }
 
 impl Worktrees {
@@ -53,7 +53,7 @@ impl Worktrees {
         self.inner.remove(&self.main).unwrap()
     }
 
-    pub fn into_inner(self) -> HashMap<Utf8PathBuf, Worktree> {
+    pub fn into_inner(self) -> FxHashMap<Utf8PathBuf, Worktree> {
         self.inner
     }
 
@@ -68,7 +68,7 @@ impl Worktrees {
         main.is_main = true;
         let main_path = main.path.clone();
 
-        let mut inner: HashMap<_, _> = repeat_till(
+        let mut inner: FxHashMap<_, _> = repeat_till(
             0..,
             Worktree::parser.map(|worktree| (worktree.path.clone(), worktree)),
             eof,
@@ -122,7 +122,7 @@ impl Worktrees {
 }
 
 impl Deref for Worktrees {
-    type Target = HashMap<Utf8PathBuf, Worktree>;
+    type Target = FxHashMap<Utf8PathBuf, Worktree>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/src/git/worktree/resolve_unique_names.rs
+++ b/src/git/worktree/resolve_unique_names.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use rustc_hash::FxHashMap as HashMap;
-use rustc_hash::FxHashSet as HashSet;
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use tracing::instrument;
 
 use crate::git::GitLike;
@@ -20,12 +20,12 @@ pub struct ResolveUniqueNameOpts<'a> {
     /// The worktrees to resolve into unique names.
     pub worktrees: Worktrees,
     /// A starting set of unique names that the resolved names will not conflict with.
-    pub names: HashSet<String>,
+    pub names: FxHashSet<String>,
     /// A set of directory names that the resolved names will not include.
     ///
     /// This is used to prevent worktree paths like `my-repo/my-repo` for detached `HEAD`
     /// worktrees.
-    pub directory_names: &'a HashSet<&'a str>,
+    pub directory_names: &'a FxHashSet<&'a str>,
 }
 
 /// When we convert a repository into a worktree checkout, we put all the worktrees in one
@@ -49,7 +49,7 @@ pub struct ResolveUniqueNameOpts<'a> {
 pub fn resolve_unique_worktree_names<C>(
     git: &AppGit<'_, C>,
     mut opts: ResolveUniqueNameOpts<'_>,
-) -> miette::Result<HashMap<Utf8PathBuf, RenamedWorktree>>
+) -> miette::Result<FxHashMap<Utf8PathBuf, RenamedWorktree>>
 where
     C: AsRef<Utf8Path>,
 {
@@ -79,13 +79,13 @@ where
 ///
 /// Returns the set of resolved names and the remaining worktrees.
 fn handle_bare_main_worktree(
-    names: &mut HashSet<String>,
+    names: &mut FxHashSet<String>,
     mut worktrees: Worktrees,
 ) -> (
-    HashMap<Utf8PathBuf, RenamedWorktree>,
-    HashMap<Utf8PathBuf, Worktree>,
+    FxHashMap<Utf8PathBuf, RenamedWorktree>,
+    FxHashMap<Utf8PathBuf, Worktree>,
 ) {
-    let mut resolved = HashMap::default();
+    let mut resolved = FxHashMap::default();
     debug_assert!(
         !names.contains(".git"),
         "`.git` cannot be a reserved worktree name"
@@ -127,7 +127,7 @@ pub struct RenamedWorktree {
 struct WorktreeNames<'a, C> {
     git: &'a AppGit<'a, C>,
     worktree: &'a Worktree,
-    directory_names: &'a HashSet<&'a str>,
+    directory_names: &'a FxHashSet<&'a str>,
 }
 
 impl<'a, C> WorktreeNames<'a, C>
@@ -137,7 +137,7 @@ where
     fn new(
         git: &'a AppGit<'a, C>,
         worktree: &'a Worktree,
-        directory_names: &'a HashSet<&'a str>,
+        directory_names: &'a FxHashSet<&'a str>,
     ) -> Self {
         Self {
             git,
@@ -246,7 +246,7 @@ mod tests {
                     .worktrees
                     .into_iter()
                     .map(|worktree| (worktree.path.clone(), worktree))
-                    .collect::<HashMap<_, _>>(),
+                    .collect::<FxHashMap<_, _>>(),
             };
 
             let mut worktrees = resolve_unique_worktree_names(

--- a/src/topological_sort.rs
+++ b/src/topological_sort.rs
@@ -1,8 +1,8 @@
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use miette::miette;
-use rustc_hash::FxHashMap as HashMap;
-use rustc_hash::FxHashSet as HashSet;
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 /// Topologically sort a set of paths.
 ///
@@ -23,8 +23,8 @@ where
     }
 
     // Compute edges.
-    let mut edges = HashMap::<&Utf8Path, HashSet<&Utf8Path>>::default();
-    let mut incoming_edges = HashMap::<&Utf8Path, HashSet<&Utf8Path>>::default();
+    let mut edges = FxHashMap::<&Utf8Path, FxHashSet<&Utf8Path>>::default();
+    let mut incoming_edges = FxHashMap::<&Utf8Path, FxHashSet<&Utf8Path>>::default();
     for (i, path1) in paths[..paths.len()].iter().enumerate() {
         let path1 = path1.as_ref();
         if path1.is_relative() {

--- a/test-harness/src/repo_state.rs
+++ b/test-harness/src/repo_state.rs
@@ -20,7 +20,7 @@ use git_prole::WorktreeHead;
 use itertools::Itertools;
 use pretty_assertions::assert_eq;
 use pretty_assertions::Comparison;
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::FxHashMap;
 
 /// A repository state, which can be checked against a real repository.
 #[derive(Debug)]
@@ -92,7 +92,7 @@ impl RepoState {
                         worktree,
                     )
                 })
-                .collect::<HashMap<_, _>>();
+                .collect::<FxHashMap<_, _>>();
 
             for (_, actual) in actual_worktrees.iter() {
                 let expected = match expected_worktrees.remove(&actual.path) {


### PR DESCRIPTION
`rust-analyzer` doesn't suggest aliased imports, so this will keep things consistent in the future.