### PR TITLE
Release version 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "git-prole"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "calm_io",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ publish = false # Don't do `cargo publish`.
 
 [package]
 name = "git-prole"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Rebecca Turner <rbt@sent.as>"]
 description = "A git-worktree(1) manager"


### PR DESCRIPTION
Update version to 0.5.1 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.