### PR TITLE
Remove footgun with `add.branch_replacements`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -94,6 +94,9 @@ commands = [
 # `git prole add -b ...` will create a directory named `some-ticket-title`.
 # (The branch name will still be unchanged and way too long.)
 #
+# Note that if the result of applying your regex substitutions includes a `/`,
+# the last component of the result will be used.
+#
 # For completeness, you can also specify how many replacements are performed:
 #
 #     [[add.branch_replacements]]

--- a/src/git/worktree/mod.rs
+++ b/src/git/worktree/mod.rs
@@ -272,7 +272,20 @@ where
                 }
                 .into_owned();
             }
-            dirname.into()
+
+            if dirname.contains(std::path::MAIN_SEPARATOR_STR) {
+                let final_component = final_component(&dirname);
+                tracing::warn!(
+                    %branch,
+                    after_replacements=%dirname,
+                    using=%final_component,
+                    "Applying `add.branch_replacements` substitutions resulted in a directory name which includes a `{}`",
+                    std::path::MAIN_SEPARATOR_STR,
+                );
+                final_component.to_owned().into()
+            } else {
+                dirname.into()
+            }
         }
     }
 

--- a/tests/add_destination_exists.rs
+++ b/tests/add_destination_exists.rs
@@ -1,0 +1,21 @@
+use command_error::CommandExt;
+use test_harness::GitProle;
+
+#[test]
+fn add_destination_exists() -> miette::Result<()> {
+    let prole = GitProle::new().unwrap();
+    prole.setup_worktree_repo("my-repo").unwrap();
+
+    prole.sh(r#"
+        cd my-repo || exit
+        mkdir puppy
+    "#)?;
+
+    prole
+        .cd_cmd("my-repo/main")
+        .args(["add", "puppy"])
+        .status_checked()
+        .unwrap_err();
+
+    Ok(())
+}

--- a/tests/config_add_branch_replacements_path_separator.rs
+++ b/tests/config_add_branch_replacements_path_separator.rs
@@ -1,0 +1,36 @@
+use command_error::CommandExt;
+use test_harness::GitProle;
+use test_harness::WorktreeState;
+
+#[test]
+fn config_add_branch_replacements_path_separator() -> miette::Result<()> {
+    let prole = GitProle::new()?;
+    prole.setup_worktree_repo("my-repo")?;
+    prole.write_config(
+        r#"
+        [[add.branch_replacements]]
+        find = "doggy"
+        replace = "silly"
+        "#,
+    )?;
+
+    prole
+        .cd_cmd("my-repo/main")
+        .args(["add", "-b", "puppy/doggy"])
+        .status_checked()
+        .unwrap();
+
+    prole
+        .repo_state("my-repo")
+        .worktrees([
+            WorktreeState::new_bare(),
+            WorktreeState::new("main").branch("main"),
+            // Last component of the result of the replacements is used:
+            WorktreeState::new("silly")
+                .branch("puppy/doggy")
+                .upstream("main"),
+        ])
+        .assert();
+
+    Ok(())
+}


### PR DESCRIPTION
If you defined `add.branch_replacements` in your `config.toml`, but the result of applying the replacements included a `/`, `git-prole` would naively use that as the basename of a directory, causing problems (like the parent directory not existing).

Now, the last component of the result is used, to match the behavior when `add.branch_replacements` is not set.

Fixes #91 