### PR TITLE
Fix git config get (`--get` is an option)

### DIFF
--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -40,7 +40,7 @@ where
         Ok(self
             .0
             .command()
-            .args(["config", "get", "--null", key])
+            .args(["config", "--get", "--null", key])
             .output_checked_as(|context: OutputContext<Utf8Output>| {
                 if context.status().success() {
                     // TODO: Should this be a winnow parser?


### PR DESCRIPTION
I tried converting a local git repo and it failed with the following error:
```shell
$ git prole convert
Error:   × `git` failed: exit status: 2
  │ Command failed: `cd /path/to/repo && git config get --null checkout.defaultRemote`
  │ Stderr:
  │   Fehler: Schlüssel enthält keine Sektion: get
```

To get a config entry, you need to write `--get` instead of `get`. With this PR, the error no longer shows up.