### PR TITLE
Convert creates tempdir in parent of destination

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -63,6 +63,14 @@ path = "std::fs::read_to_string"
 reason = "Use git_prole::fs::read_to_string"
 
 [[disallowed-methods]]
+path = "fs_err::read_dir"
+reason = "Use git_prole::fs::read_dir"
+
+[[disallowed-methods]]
+path = "std::fs::read_dir"
+reason = "Use git_prole::fs::read_dir"
+
+[[disallowed-methods]]
 path = "fs_err::copy"
 reason = "Use git_prole::fs::copy"
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::Debug;
 use std::path::Path;
+use std::path::PathBuf;
 
 use miette::IntoDiagnostic;
 use tracing::instrument;
@@ -71,4 +72,13 @@ where
 {
     #[expect(clippy::disallowed_methods)]
     fs_err::write(path, contents).into_diagnostic()
+}
+
+#[instrument(level = "trace")]
+pub fn read_dir<P>(path: P) -> miette::Result<fs_err::ReadDir>
+where
+    P: Into<PathBuf> + Debug,
+{
+    #[expect(clippy::disallowed_methods)]
+    fs_err::read_dir(path).into_diagnostic()
 }

--- a/src/path_display.rs
+++ b/src/path_display.rs
@@ -30,10 +30,13 @@ pub trait PathDisplay: Debug + AsRef<Path> {
 
 impl<P> PathDisplay for P
 where
-    P: AsRef<Utf8Path> + AsRef<Path> + Debug,
+    P: AsRef<Path> + Debug,
 {
     fn display_path_from(&self, base: impl AsRef<Utf8Path>) -> String {
-        try_display(self, base).unwrap_or_else(|| display_backup(self))
+        let path = self.as_ref();
+        Utf8Path::from_path(path)
+            .and_then(|utf8path| try_display(utf8path, base))
+            .unwrap_or_else(|| display_backup(self))
     }
 }
 

--- a/src/utf8tempdir.rs
+++ b/src/utf8tempdir.rs
@@ -14,8 +14,8 @@ pub struct Utf8TempDir {
 }
 
 impl Utf8TempDir {
-    pub fn new() -> miette::Result<Self> {
-        let inner = tempfile::tempdir().into_diagnostic()?;
+    pub fn new(parent_dir: &Utf8PathBuf) -> miette::Result<Self> {
+        let inner = tempfile::tempdir_in(parent_dir).into_diagnostic()?;
         let path = inner.path().to_owned().try_into().into_diagnostic()?;
         Ok(Self {
             inner: Some(inner),

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -29,7 +29,7 @@ pub struct GitProle {
 
 impl GitProle {
     pub fn new() -> miette::Result<Self> {
-        let mut tempdir = Utf8TempDir::new()?;
+        let mut tempdir = Utf8TempDir::new(&Utf8PathBuf::from("./"))?;
 
         if std::env::var("KEEP_TEMP").is_ok() {
             tempdir.persist();


### PR DESCRIPTION
Fixes issue https://github.com/9999years/git-prole/issues/96

I tested the change on some repos (no longer gives the error) and ran the tests with `nix flake check`.
Please do review this carefully since I'm still pretty new to Rust. ^^

### Change summary
`git prole convert` now creates a tempdir in the parent of the determined destination of the converted repo.
This prevents some errors when the /tmp directory is on a different filesystem, such as a tmpfs.

The tempdir will be deleted if and only if it is empty after conversion. This should always be the case and is to prevent any data loss.
